### PR TITLE
jsbeautifier: move import

### DIFF
--- a/jsbeautifier/__init__.py
+++ b/jsbeautifier/__init__.py
@@ -1,6 +1,7 @@
 import sys
 import getopt
 import re
+import jsbeautifier.unpackers as unpackers
 import string
 
 #
@@ -242,7 +243,6 @@ class Beautifier:
         return sweet_code
 
     def unpack(self, source, evalcode=False):
-        import jsbeautifier.unpackers as unpackers
         try:
             return unpackers.run(source, evalcode)
         except unpackers.UnpackingError as error:


### PR DESCRIPTION
When jsbeautifier.unpacker failed to import, exception is catch by JSAnalysis module and handled transparently.

To reproduce the error : 
    - You are in peepdf repo
    - Create `reproduct_error.py` at `../` with : 
          
```
 from peepdf import *
 from peepdf.PDFCore import *

 pdfparser = PDFParser()
 ret, pdf = pdfparser.parse(<pdf_file_toanalyse>)
 print pdf.getJavascriptCode(None)
```

Expected output : a list of java script code (obviously, if your pdf contains some)
Actual output : `Error: An error has occurred while parsing an indirect object!!`
And with `forceMode=True`, output will be an empty array.

With this patch, the same script will raise ImportException. This is a lot easier to understand and debug.