### PR TITLE
intoduce setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,10 @@
+from setuptools import find_packages, setup
+
+setup(
+    name = "PeePDF",
+    version = "0.3-r235",
+    author = "Jose Miguel Esparza",
+    license = "GNU GPLv3",
+    url = "http://eternal-todo.com",
+    packages = find_packages(),
+)


### PR DESCRIPTION
Create an importable module for peepdf with setuptools
So we can use easily peepdf as a lib, and somehow fix the pointed issue by #50. (ImportException raised if we don't launch our script from peepdf repo.)
I think this PR and #50 should be both merge, although this one will fix the issue of #50 while running `python setup.py install`/`python setup.py develop`.
btw, do you think about uploading your project to pypi ?