### PR TITLE
Do not ignore whitespace past opening delimiter in string literals

### DIFF
--- a/PDFCore.py
+++ b/PDFCore.py
@@ -7816,7 +7816,7 @@ class PDFParser :
         else:
             delimiters = self.delimiters
         for delim in delimiters:
-            ret = self.readSymbol(content, delim[0])
+            ret = self.readSymbol(content, delim[0], False if delim[0] == '(' else True)
             if ret[0] != -1:
                 if delim[2] == 'dictionary':
                     ret = self.readUntilClosingDelim(content, delim)


### PR DESCRIPTION
This is to fix a parser bug that can arise when extracting encryption passwords that have a whitespace character as the first byte (e.g. the /O string value in the Encrypt object below has a form feed as the first byte):

```
000007c0  3e 20 0d 65 6e 64 6f 62  6a 0d 39 31 20 30 20 6f  |> .endobj.91 0 o|
000007d0  62 6a 0d 3c 3c 20 0d 2f  46 69 6c 74 65 72 20 2f  |bj.<< ./Filter /|
000007e0  53 74 61 6e 64 61 72 64  20 0d 2f 52 20 32 20 0d  |Standard ./R 2 .|
000007f0  2f 4f 20 28 0c ab 2a 5f  6e 12 5c 28 92 57 f1 80  |/O (..*_n.\(.W..|
00000800  4b c3 6c b5 f0 a5 56 33  9e ee be dd 33 8a b4 36  |K.l...V3....3..6|
00000810  33 e1 a5 da d9 29 0d 2f  55 20 28 ba 08 e0 40 ef  |3....)./U (...@.|
00000820  5c 28 a0 63 ae f9 d8 a5  e6 ee dd 46 bb 3d fd ae  |\(.c.......F.=..|
00000830  21 41 f9 b2 2d 2a 88 e8  4e 5f e4 8d 29 0d 2f 50  |!A..-*..N_..)./P|
00000840  20 2d 32 38 20 0d 2f 56  20 31 20 0d 2f 4c 65 6e  | -28 ./V 1 ./Len|
00000850  67 74 68 20 34 30 20 0d  3e 3e 20 0d 65 6e 64 6f  |gth 40 .>> .endo|
00000860  62 6a 0d 39 32 20 30 20  6f 62 6a 0d 3c 3c 20 0d  |bj.92 0 obj.<< .|
```

The parser will then erroneously extract the opening '(' delimiter and skip the first byte of the /O password value, causing decryption errors while processing the encrypted objects.